### PR TITLE
Added license scanning - part 1

### DIFF
--- a/.github/workflows/license_scan.yaml
+++ b/.github/workflows/license_scan.yaml
@@ -1,0 +1,20 @@
+name: Third-Party License Scan
+
+on:
+  workflow_call:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          config-file: allianz/ospo/config/license_scan.yml@main

--- a/config/archive_repos.yaml
+++ b/config/archive_repos.yaml
@@ -1,3 +1,12 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Allianz OSPO — Repository Archival Configuration
+#
+# This file controls how stale repositories are detected and archived in the
+# Allianz GitHub organization. Repos with no push activity for warn_after are
+# warned via a GitHub issue, then archived after the grace_period has elapsed.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
 # List of repositories to exclude from automatic archiving after stale period
 excluded_repos:
   - .github

--- a/config/create_repos.yaml
+++ b/config/create_repos.yaml
@@ -1,8 +1,11 @@
-# Configuration File for GitHub Repositories
+# ──────────────────────────────────────────────────────────────────────────────
+# Allianz OSPO — Repository Creation Configuration
 #
-# This file manages settings for GitHub repositories within the Allianz organization.
-# Each entry represents a repository that should exist in the org with the
-# specified team assignments and policy settings.
+# This file defines which repositories should exist in the Allianz GitHub
+# organization, along with their team assignments and policy settings.
+# The creation pipeline applies this configuration automatically on merge.
+#
+# ──────────────────────────────────────────────────────────────────────────────
 #
 # Adding a new repository:
 #   1. Add an entry under `repositories` with the repo name

--- a/config/license_scan.yaml
+++ b/config/license_scan.yaml
@@ -1,0 +1,28 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Allianz OSPO — Third-Party License Policy
+#
+# This file defines which open-source licenses are denied in pull requests
+# across the Allianz GitHub organization. It is used by the dependency review
+# action to block PRs that introduce dependencies with non-compliant licenses.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+vulnerability-check: false
+license-check: true
+deny-licenses:
+  # Copyleft
+  - GPL-2.0
+  - GPL-2.0-only
+  - GPL-2.0-or-later
+  - GPL-3.0
+  - GPL-3.0-only
+  - GPL-3.0-or-later
+  - AGPL-3.0
+  - AGPL-3.0-only
+  - AGPL-3.0-or-later
+  # Commercial / source-available
+  - BUSL-1.1
+  - Elastic-2.0
+  - SSPL-1.0
+  - PolyForm-Noncommercial-1.0.0
+  - PolyForm-Small-Business-1.0.0


### PR DESCRIPTION
* I added a third party license scanning
* It is github action that scans the Github dependency tree
* Also improved a few docs

Next steps:
1. Configure rule set that runs the github action on all PRs over all repos in the org
2. Update the create_repos.js to allow opt out. This will be second PR