### PR TITLE
Minor wording improvement

### DIFF
--- a/config/create_repos.yaml
+++ b/config/create_repos.yaml
@@ -14,7 +14,7 @@
 #                       'custom' — repo team controls GHAS settings
 #   branch-protection:  'managed' (default) — OSPO enforces branch protection via org ruleset
 #                       'custom' — repo team defines its own branch protection rules
-#   access[].team:      Team display name; must match the corresponding Entra ID group name exactly
+#   access[].team:      GIAM group granting repository access (synced to a GitHub team)
 #   access[].role:      'own' (default) — full repo ownership via custom org role
 #                       'write' — push access
 #                       'triage' — read + triage issues and PRs, no push access


### PR DESCRIPTION
access[].team:      GIAM group granting repository access (synced to a GitHub team)
Or:
 access[].team:     GitHub team granting repository access (synced to the GIAM group with same name)