### PR TITLE
Improve lint check: issue updates, min_chars check, NOTICE/AUTHORS files

### DIFF
--- a/config/lint_repos.yaml
+++ b/config/lint_repos.yaml
@@ -63,7 +63,7 @@ allowed_licenses:
 required_files:
   - pattern: "README*"
     description: "Readme File"
-    min_chars: 100
+    min_chars: 300
   - pattern: "CONTRIBUTING*"
     search_paths: [".", ".github", "docs"]
     description: "Contributing File"

--- a/config/lint_repos.yaml
+++ b/config/lint_repos.yaml
@@ -63,11 +63,16 @@ allowed_licenses:
 required_files:
   - pattern: "README*"
     description: "Readme File"
+    min_chars: 100
   - pattern: "CONTRIBUTING*"
     search_paths: [".", ".github", "docs"]
     description: "Contributing File"
   - pattern: "LICENSE*"
     description: "License File"
+  - pattern: "NOTICE*"
+    description: "Notice File"
+  - pattern: "AUTHORS*"
+    description: "Authors File"
 
 # Allowed topics for repositories. New topics can be suggested.
 # Topics are used for filtering and organisation-wide statistics, so a controlled

--- a/scripts/lint_repos.js
+++ b/scripts/lint_repos.js
@@ -181,10 +181,11 @@ async function cloneOrUpdate(repoName, cloneDir, org, debug) {
   if (exists) {
     try {
       const git = simpleGit(cloneDir);
-      const fetchResult = await git.fetch(['origin', '--depth', '1']);
-      // Empty repos have nothing to reset to — skip the reset
-      if (fetchResult.branches.length > 0 || fetchResult.tags.length > 0) {
-        await git.reset(['--hard', 'origin/HEAD']);
+      await git.fetch(['origin', '--depth', '1']);
+      try {
+        await git.reset(['--hard', 'FETCH_HEAD']);
+      } catch {
+        // FETCH_HEAD not set — repo is empty on remote, nothing to reset to
       }
     } catch {
       // Stale or corrupt clone — delete and re-clone from scratch

--- a/scripts/lint_repos.js
+++ b/scripts/lint_repos.js
@@ -80,7 +80,7 @@ export function checkLicense(repo, allowedLicenses) {
 }
 
 export async function checkRequiredFile(cloneDir, fileSpec) {
-  const { pattern, search_paths } = fileSpec;
+  const { pattern, search_paths, min_chars } = fileSpec;
   const searchPaths = search_paths ?? ['.'];
   // Patterns are always prefix globs (README*, CONTRIBUTING*, LICENSE*) — match case-insensitively
   const prefix = pattern.replace(/\*.*$/, '').toUpperCase();
@@ -89,7 +89,15 @@ export async function checkRequiredFile(cloneDir, fileSpec) {
     try {
       const entries = await readdir(dir);
       const match = entries.find(f => f.toUpperCase().startsWith(prefix));
-      if (match) return { passed: true };
+      if (match) {
+        if (min_chars != null) {
+          const content = await readFile(path.join(dir, match), 'utf8');
+          if (content.length < min_chars) {
+            return { passed: false, detail: `File exists but is too short (${content.length} chars; minimum is ${min_chars})` };
+          }
+        }
+        return { passed: true };
+      }
     } catch {
       // Directory doesn't exist — try next path
     }
@@ -129,12 +137,16 @@ async function findOpenIssue(octokit, org, repo, issueTitle) {
     repo,
     state: 'open',
   });
-  const found = issues.find(i => i.title === issueTitle);
+  const found = issues.find(i => i.title === issueTitle && !i.pull_request);
   return found ? found.number : null;
 }
 
 async function createIssue(octokit, org, repo, title, body) {
   await octokit.rest.issues.create({ owner: org, repo, title, body });
+}
+
+async function updateIssue(octokit, org, repo, issueNumber, body) {
+  await octokit.rest.issues.update({ owner: org, repo, issue_number: issueNumber, body });
 }
 
 async function closeIssue(octokit, org, repo, issueNumber) {
@@ -278,6 +290,7 @@ async function main() {
 
   let anyFailed = false;
   const pendingCreates = [];
+  const pendingUpdates = [];
   const pendingCloses = [];
 
   for (const repo of active) {
@@ -304,12 +317,18 @@ async function main() {
         }
       }
       const existingIssue = await findOpenIssue(octokit, org, repo.name, config.issue_title);
+      const body = buildIssueBody(allChecks, config.docs_link);
       if (!existingIssue) {
         if (dryRun) {
           pendingCreates.push(repo.name);
         } else {
-          const body = buildIssueBody(allChecks, config.docs_link);
           await createIssue(octokit, org, repo.name, config.issue_title, body);
+        }
+      } else {
+        if (dryRun) {
+          pendingUpdates.push({ number: existingIssue, name: repo.name });
+        } else {
+          await updateIssue(octokit, org, repo.name, existingIssue, body);
         }
       }
     } else {
@@ -348,15 +367,17 @@ async function main() {
     }
   }
 
-  if (dryRun && (pendingCreates.length > 0 || pendingCloses.length > 0)) {
-    const createWord = pendingCreates.length !== 1 ? 'issues' : 'issue';
+  if (dryRun && (pendingCreates.length > 0 || pendingUpdates.length > 0 || pendingCloses.length > 0)) {
     console.log('');
-    console.log(`──── Dry-run: ${pendingCreates.length} ${createWord} would be created, ${pendingCloses.length} would be closed ────`);
+    console.log(`──── Dry-run: ${pendingCreates.length} would be created, ${pendingUpdates.length} would be updated, ${pendingCloses.length} would be closed ────`);
     for (const name of pendingCreates) {
       console.log(`  ✉️   create  ${name}`);
     }
+    for (const { number, name } of pendingUpdates) {
+      console.log(`  ✏️   update  #${number}  ${name}`);
+    }
     for (const { number, name } of pendingCloses) {
-      console.log(`  ✔️   close  #${number}  ${name}`);
+      console.log(`  ✔️   close   #${number}  ${name}`);
     }
   }
 

--- a/scripts/lint_repos.test.js
+++ b/scripts/lint_repos.test.js
@@ -280,6 +280,42 @@ describe('checkRequiredFile', () => {
     });
     assert.equal(r.passed, true);
   });
+
+  it('passes when file meets min_chars exactly', async () => {
+    const sizeDir = await mkdtemp(path.join(tmpdir(), 'lint-size-'));
+    try {
+      await writeFile(path.join(sizeDir, 'README.md'), 'x'.repeat(300));
+      const r = await checkRequiredFile(sizeDir, { pattern: 'README*', min_chars: 300 });
+      assert.equal(r.passed, true);
+    } finally {
+      await rm(sizeDir, { recursive: true });
+    }
+  });
+
+  it('fails when file exists but is below min_chars', async () => {
+    const sizeDir = await mkdtemp(path.join(tmpdir(), 'lint-size-'));
+    try {
+      await writeFile(path.join(sizeDir, 'README.md'), 'x'.repeat(50));
+      const r = await checkRequiredFile(sizeDir, { pattern: 'README*', min_chars: 300 });
+      assert.equal(r.passed, false);
+      assert.match(r.detail, /too short/);
+      assert.match(r.detail, /50 chars/);
+      assert.match(r.detail, /minimum is 300/);
+    } finally {
+      await rm(sizeDir, { recursive: true });
+    }
+  });
+
+  it('passes without size check when min_chars is absent', async () => {
+    const sizeDir = await mkdtemp(path.join(tmpdir(), 'lint-size-'));
+    try {
+      await writeFile(path.join(sizeDir, 'README.md'), 'tiny');
+      const r = await checkRequiredFile(sizeDir, { pattern: 'README*' });
+      assert.equal(r.passed, true);
+    } finally {
+      await rm(sizeDir, { recursive: true });
+    }
+  });
 });
 
 // ── buildIssueBody ────────────────────────────────────────────────────────────

--- a/scripts/spec/lint_repos_spec.md
+++ b/scripts/spec/lint_repos_spec.md
@@ -158,7 +158,8 @@ Checks 1, 2, and 3 use only API data (no clone needed). Check 4 requires the loc
    Split into active (archived: false, not excluded), archived (archived: true, not excluded), and excluded (name in `excluded_repos`) lists
 6. Run metadata checks (description, topics, license type) for all repos from API data
 7. Clone/update active repos in batches of 5 using simple-git:
-     - Directory exists: git.fetch() + git.reset(['--hard', 'origin/HEAD'])
+     - Directory exists: git.fetch(['origin', '--depth', '1']) + git.reset(['--hard', 'FETCH_HEAD'])
+       (shallow fetches only write to FETCH_HEAD, not to a tracking ref, so FETCH_HEAD is the correct reset target)
      - Directory missing: git.clone(url, lint_cache/<repo>)
    Batches run sequentially; the 5 clones within each batch run in parallel via Promise.all
    Archived repos are not cloned.

--- a/scripts/spec/lint_repos_spec.md
+++ b/scripts/spec/lint_repos_spec.md
@@ -100,8 +100,8 @@ allowed_licenses:
 # (e.g. README* matches README.md). description is used as the check name in
 # issue body and output. search_paths defaults to ["."] if omitted.
 # min_chars (optional): if set, the matched file must also be at least this many
-# bytes; a file that exists but is smaller fails with "File exists but is too small
-# (<actual> bytes; minimum is <min_chars>)".
+# chars; a file that exists but is smaller fails with "File exists but is too short
+# (<actual> chars; minimum is <min_chars>)".
 required_files:
   - pattern: "README*"
     description: "Readme File"

--- a/scripts/spec/lint_repos_spec.md
+++ b/scripts/spec/lint_repos_spec.md
@@ -99,14 +99,22 @@ allowed_licenses:
 # file in the specified search_paths. pattern is a case-insensitive prefix glob
 # (e.g. README* matches README.md). description is used as the check name in
 # issue body and output. search_paths defaults to ["."] if omitted.
+# min_chars (optional): if set, the matched file must also be at least this many
+# bytes; a file that exists but is smaller fails with "File exists but is too small
+# (<actual> bytes; minimum is <min_chars>)".
 required_files:
   - pattern: "README*"
     description: "Readme File"
+    min_chars: 300
   - pattern: "CONTRIBUTING*"
     search_paths: [".", ".github", "docs"]
     description: "Contributing File"
   - pattern: "LICENSE*"
     description: "License File"
+  - pattern: "NOTICE*"
+    description: "Notice File"
+  - pattern: "AUTHORS*"
+    description: "Authors File"
 
 # Minimum and maximum character length for repository descriptions (inclusive).
 # Descriptions outside this range fail the check. Defaults: min: 30, max: 150.
@@ -131,7 +139,7 @@ allowed_topics:
 | 1 | **Description** | GitHub API | `description` is non-null, non-empty, and between `description_length.min` and `description_length.max` chars (inclusive) |
 | 2 | **Topics** | GitHub API | Between 1 and 5 topics assigned; all topics must be in `allowed_topics` |
 | 3 | **License type** | GitHub API | `license.spdx_id` is in `allowed_licenses`; fails with a clear message if API returns null (no license detected) or `NOASSERTION` (custom license text GitHub could not identify) |
-| 4 | **Required files** | Local clone | Each `required_files` entry matches at least one file in the specified `search_paths` (includes LICENSE*) |
+| 4 | **Required files** | Local clone | Each `required_files` entry matches at least one file in the specified `search_paths`; if `min_chars` is set the matched file must also meet that size threshold |
 
 Checks 1, 2, and 3 use only API data (no clone needed). Check 4 requires the local clone.
 
@@ -159,6 +167,7 @@ Checks 1, 2, and 3 use only API data (no clone needed). Check 4 requires the loc
    b. Aggregate metadata + file check results into a failures list
    c. Failures present:
         - If no open issue with matching title exists: create issue (unless --dry-run)
+        - If an open issue with matching title exists: update its body with the current check results (unless --dry-run)
    d. All checks pass:
         - If an open issue with matching title exists: close it with a resolved comment (unless --dry-run)
    e. Print summary line to stdout
@@ -174,7 +183,7 @@ Checks 1, 2, and 3 use only API data (no clone needed). Check 4 requires the loc
 | Repo state | Existing issue? | Action |
 |---|---|---|
 | Non-compliant | No open issue | Create issue |
-| Non-compliant | Open issue exists | Leave open (no duplicate) |
+| Non-compliant | Open issue exists | Update issue body with current check results |
 | Compliant | Open issue exists | Close issue with resolved comment |
 | Compliant | No open issue | No action |
 | Archived (any) | — | No issue action |
@@ -254,10 +263,11 @@ Skipped (configuration)
 When `--dry-run` is active and there are pending actions, a summary block is appended after the archived section:
 
 ```
-──── Dry-run: 2 issues would be created, 1 would be closed ────
+──── Dry-run: 2 issues would be created, 1 would be updated, 1 would be closed ────
   ✉️   create  another-repo
   ✉️   create  fourth-repo
-  ✔️   close  #42  third-repo
+  ✏️   update  #17  fifth-repo
+  ✔️   close   #42  third-repo
 ```
 
 ---
@@ -288,7 +298,7 @@ Each check function is tested in isolation with fake API responses and a tempora
 - **Description:** set, empty string, null
 - **Topics:** none assigned; topic not in `allowed_topics`; `allowed_topics` empty (any accepted)
 - **License type:** allowed, disallowed, API returns null, API returns `NOASSERTION` (custom license text)
-- **Required files:** all present; each file missing individually; match in `search_paths` subdirectory; case-insensitive match
+- **Required files:** all present; each file missing individually; match in `search_paths` subdirectory; case-insensitive match; file exists but is below `min_chars` threshold; file meets `min_chars` threshold exactly; `min_chars` absent (size not checked)
 - **Config loading:** valid config; missing required field `issue_title`; `allowed_topics` absent (defaults to empty); `excluded_repos` absent (defaults to empty); `excluded_repos` list preserved
 
 ### Integration test (against `ospo-sandbox`)

--- a/scripts/test-config/lint_repos.yaml
+++ b/scripts/test-config/lint_repos.yaml
@@ -9,11 +9,16 @@ excluded_repos: []
 required_files:
   - pattern: "README*"
     description: "Readme File"
+    min_chars: 100
   - pattern: "CONTRIBUTING*"
     search_paths: [".", ".github", "docs"]
     description: "Contributing File"
   - pattern: "LICENSE*"
     description: "License File"
+  - pattern: "NOTICE*"
+    description: "Notice File"
+  - pattern: "AUTHORS*"
+    description: "Authors File"
 
 allowed_licenses:
   - Apache-2.0


### PR DESCRIPTION
  - Update existing issues on re-run — when a non-compliant repo already has an open lint issue, the body is updated with the latest check results. Previously partial fixes were invisible until all checks passed.
  - Minimum content check for README — a new optional min_chars field on required_files entries fails a file that exists but is too short. README is set to 100 chars to catch auto-generated single-line readmes.
  - NOTICE and AUTHORS files are now required — added to required_files in production and test configs.
  - Fix stale clone not updating — shallow clones only write to FETCH_HEAD, not to a tracking ref. Changed the reset target from origin/HEAD to FETCH_HEAD so clones are actually updated.