### PR TITLE
Fix workflow warning

### DIFF
--- a/.github/workflows/archive_repos.yaml
+++ b/.github/workflows/archive_repos.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.ALLIANZ_APP_ID }}
+          client-id: ${{ secrets.ALLIANZ_APP_ID }}
           private-key: ${{ secrets.ALLIANZ_APP_PRIVATE_KEY }}
           owner: allianz
 

--- a/.github/workflows/create_repos.yaml
+++ b/.github/workflows/create_repos.yaml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
-        app-id: ${{ secrets.ALLIANZ_APP_ID }}
+        client-id: ${{ secrets.ALLIANZ_APP_ID }}
         private-key: ${{ secrets.ALLIANZ_APP_PRIVATE_KEY }}
         owner: allianz
 
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
-        app-id: ${{ secrets.ALLIANZ_APP_ID }}
+        client-id: ${{ secrets.ALLIANZ_APP_ID }}
         private-key: ${{ secrets.ALLIANZ_APP_PRIVATE_KEY }}
         owner: allianz
 

--- a/.github/workflows/license_scan.yaml
+++ b/.github/workflows/license_scan.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.ALLIANZ_APP_ID }}
+          client-id: ${{ secrets.ALLIANZ_APP_ID }}
           private-key: ${{ secrets.ALLIANZ_APP_PRIVATE_KEY }}
           owner: allianz
 

--- a/.github/workflows/lint_repos.yaml
+++ b/.github/workflows/lint_repos.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.ALLIANZ_APP_ID }}
+          client-id: ${{ secrets.ALLIANZ_APP_ID }}
           private-key: ${{ secrets.ALLIANZ_APP_PRIVATE_KEY }}
           owner: allianz
 


### PR DESCRIPTION
The new github action version produced warnings:

`Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

Updated code to remove warning